### PR TITLE
Migrate to Rust 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/stbuehler/rust-async-dnssd"
 readme = "README.md"
 keywords = ["dnssd", "dns-sd", "mdns", "network", "async"]
 license = "MIT"
+edition = "2018"
 
 [build-dependencies]
 pkg-config = "0.3.9"

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,3 @@
-extern crate pkg_config;
-
 use std::env::{
 	var,
 	var_os,

--- a/examples/browse.rs
+++ b/examples/browse.rs
@@ -1,7 +1,3 @@
-extern crate async_dnssd;
-extern crate futures;
-extern crate tokio;
-
 use async_dnssd::{
 	TimeoutTrait,
 	TxtRecord,

--- a/examples/enumerate-domains.rs
+++ b/examples/enumerate-domains.rs
@@ -1,7 +1,3 @@
-extern crate async_dnssd;
-extern crate futures;
-extern crate tokio;
-
 use futures::stream::Stream;
 
 fn main() {

--- a/examples/register.rs
+++ b/examples/register.rs
@@ -1,7 +1,3 @@
-extern crate async_dnssd;
-extern crate futures;
-extern crate tokio;
-
 use async_dnssd::register;
 
 fn main() -> std::io::Result<()> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,7 +4,7 @@ use std::{
 	io,
 };
 
-use ffi;
+use crate::ffi;
 
 /// API Error
 #[derive(Clone, Copy, Eq, PartialEq, Hash)]
@@ -67,7 +67,7 @@ impl fmt::Display for ffi::DNSServiceError {
 }
 impl error::Error for ffi::DNSServiceError {
 	fn description(&self) -> &str {
-		use ffi::DNSServiceError::*;
+		use crate::ffi::DNSServiceError::*;
 		match *self {
 			Unknown => "unknown error",
 			NoSuchName => "no such name",

--- a/src/error.rs
+++ b/src/error.rs
@@ -37,7 +37,7 @@ impl From<Error> for io::Error {
 }
 
 impl fmt::Debug for Error {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		match *self {
 			Error::KnownError(ffi_err) => {
 				write!(f, "known error {:?}: {}", ffi_err, ffi_err)
@@ -47,7 +47,7 @@ impl fmt::Debug for Error {
 	}
 }
 impl fmt::Display for Error {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		match *self {
 			Error::KnownError(ffi_err) => write!(f, "{}", ffi_err),
 			Error::UnknownError(e) => write!(f, "unknown error code: {:?}", e),
@@ -61,7 +61,7 @@ impl error::Error for Error {
 }
 
 impl fmt::Display for ffi::DNSServiceError {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		write!(f, "{}", error::Error::description(self))
 	}
 }

--- a/src/evented/mod.rs
+++ b/src/evented/mod.rs
@@ -11,7 +11,7 @@ mod windows;
 use futures;
 use std::io;
 
-use raw::DNSService;
+use crate::raw::DNSService;
 
 #[must_use = "EventedDNSService does nothing unless polled"]
 pub(crate) struct EventedDNSService {

--- a/src/evented/unix.rs
+++ b/src/evented/unix.rs
@@ -1,4 +1,4 @@
-use futures::{Async, Poll};
+use futures::{Async, Poll, try_ready};
 use mio;
 use std::{
 	io,

--- a/src/evented/windows.rs
+++ b/src/evented/windows.rs
@@ -22,6 +22,7 @@ use futures::{
 	Sink,
 	Stream,
 };
+use log::debug;
 use std::{
 	cell::UnsafeCell,
 	io,

--- a/src/future.rs
+++ b/src/future.rs
@@ -9,10 +9,10 @@ use std::{
 	rc::Rc,
 };
 
-use error::Error;
-use evented::EventedDNSService;
-use ffi;
-use raw::DNSService;
+use crate::error::Error;
+use crate::evented::EventedDNSService;
+use crate::ffi;
+use crate::raw::DNSService;
 
 #[allow(clippy::borrowed_box)]
 fn box_raw<T>(ptr: &mut Box<T>) -> *mut c_void {

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use ffi;
+use crate::ffi;
 
 /// Network interface index
 ///

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -34,7 +34,7 @@ impl Into<u32> for InterfaceIndex {
 }
 
 impl fmt::Debug for InterfaceIndex {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		fmt::Debug::fmt(&self.0, f)
 	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,20 +76,6 @@
 //! [`TimeoutStream`]: struct.TimeoutStream.html
 //! [`TxtRecord`]: struct.TxtRecord.html
 
-#[macro_use]
-extern crate bitflags;
-#[macro_use]
-extern crate futures;
-extern crate libc;
-#[cfg(windows)] // only the windows event loop has debug logging for now
-#[macro_use]
-extern crate log;
-extern crate mio;
-extern crate tokio;
-
-#[cfg(windows)]
-extern crate winapi;
-
 pub use self::{
 	dns_consts::*,
 	error::*,

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -61,10 +61,10 @@ impl InnerDNSService {
 	fn register(
 		flags: ffi::DNSServiceFlags,
 		interface_index: u32,
-		name: &cstr::NullableCStr,
-		reg_type: &cstr::CStr,
-		domain: &cstr::NullableCStr,
-		host: &cstr::NullableCStr,
+		name: &cstr::NullableCStr<'_>,
+		reg_type: &cstr::CStr<'_>,
+		domain: &cstr::NullableCStr<'_>,
+		host: &cstr::NullableCStr<'_>,
 		port: u16,
 		txt: &[u8],
 		callback: ffi::DNSServiceRegisterReply,
@@ -98,8 +98,8 @@ impl InnerDNSService {
 	fn browse(
 		flags: ffi::DNSServiceFlags,
 		interface_index: u32,
-		reg_type: &cstr::CStr,
-		domain: &cstr::NullableCStr,
+		reg_type: &cstr::CStr<'_>,
+		domain: &cstr::NullableCStr<'_>,
 		callback: ffi::DNSServiceBrowseReply,
 		context: *mut c_void,
 	) -> FFIResult<InnerDNSService> {
@@ -121,9 +121,9 @@ impl InnerDNSService {
 	fn resolve(
 		flags: ffi::DNSServiceFlags,
 		interface_index: u32,
-		name: &cstr::CStr,
-		reg_type: &cstr::CStr,
-		domain: &cstr::CStr,
+		name: &cstr::CStr<'_>,
+		reg_type: &cstr::CStr<'_>,
+		domain: &cstr::CStr<'_>,
 		callback: ffi::DNSServiceResolveReply,
 		context: *mut c_void,
 	) -> FFIResult<InnerDNSService> {
@@ -152,7 +152,7 @@ impl InnerDNSService {
 	fn query_record(
 		flags: ffi::DNSServiceFlags,
 		interface_index: u32,
-		fullname: &cstr::CStr,
+		fullname: &cstr::CStr<'_>,
 		rr_type: Type,
 		rr_class: Class,
 		callback: ffi::DNSServiceQueryRecordReply,
@@ -213,10 +213,10 @@ impl DNSService {
 	pub(crate) fn register(
 		flags: ffi::DNSServiceFlags,
 		interface_index: u32,
-		name: &cstr::NullableCStr,
-		reg_type: &cstr::CStr,
-		domain: &cstr::NullableCStr,
-		host: &cstr::NullableCStr,
+		name: &cstr::NullableCStr<'_>,
+		reg_type: &cstr::CStr<'_>,
+		domain: &cstr::NullableCStr<'_>,
+		host: &cstr::NullableCStr<'_>,
 		port: u16,
 		txt: &[u8],
 		callback: ffi::DNSServiceRegisterReply,
@@ -255,8 +255,8 @@ impl DNSService {
 	pub(crate) fn browse(
 		flags: ffi::DNSServiceFlags,
 		interface_index: u32,
-		reg_type: &cstr::CStr,
-		domain: &cstr::NullableCStr,
+		reg_type: &cstr::CStr<'_>,
+		domain: &cstr::NullableCStr<'_>,
 		callback: ffi::DNSServiceBrowseReply,
 		context: *mut c_void,
 	) -> FFIResult<DNSService> {
@@ -273,9 +273,9 @@ impl DNSService {
 	pub(crate) fn resolve(
 		flags: ffi::DNSServiceFlags,
 		interface_index: u32,
-		name: &cstr::CStr,
-		reg_type: &cstr::CStr,
-		domain: &cstr::CStr,
+		name: &cstr::CStr<'_>,
+		reg_type: &cstr::CStr<'_>,
+		domain: &cstr::CStr<'_>,
 		callback: ffi::DNSServiceResolveReply,
 		context: *mut c_void,
 	) -> FFIResult<DNSService> {
@@ -294,7 +294,7 @@ impl DNSService {
 		&self,
 		flags: ffi::DNSServiceFlags,
 		interface_index: u32,
-		fullname: &cstr::CStr,
+		fullname: &cstr::CStr<'_>,
 		rr_type: Type,
 		rr_class: Class,
 		rdata: &[u8],
@@ -323,7 +323,7 @@ impl DNSService {
 	pub(crate) fn query_record(
 		flags: ffi::DNSServiceFlags,
 		interface_index: u32,
-		fullname: &cstr::CStr,
+		fullname: &cstr::CStr<'_>,
 		rr_type: Type,
 		rr_class: Class,
 		callback: ffi::DNSServiceQueryRecordReply,
@@ -399,7 +399,7 @@ impl InnerDNSRecord {
 		service: &DNSService,
 		flags: ffi::DNSServiceFlags,
 		interface_index: u32,
-		fullname: &cstr::CStr,
+		fullname: &cstr::CStr<'_>,
 		rr_type: Type,
 		rr_class: Class,
 		rdata: &[u8],
@@ -485,7 +485,7 @@ impl DNSRecord {
 pub fn reconfirm_record(
 	flags: ffi::DNSServiceFlags,
 	interface_index: u32,
-	fullname: &cstr::CStr,
+	fullname: &cstr::CStr<'_>,
 	rr_type: Type,
 	rr_class: Class,
 	rdata: &[u8],

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -10,13 +10,13 @@ use std::{
 	rc::Rc,
 };
 
-use cstr;
-use dns_consts::{
+use crate::cstr;
+use crate::dns_consts::{
 	Class,
 	Type,
 };
-use error::Error;
-use ffi;
+use crate::error::Error;
+use crate::ffi;
 
 type FFIResult<R> = Result<R, Error>;
 

--- a/src/service/browse.rs
+++ b/src/service/browse.rs
@@ -10,12 +10,12 @@ use std::{
 	},
 };
 
-use cstr;
-use ffi;
-use interface::Interface;
-use raw;
+use crate::cstr;
+use crate::ffi;
+use crate::interface::Interface;
+use crate::raw;
 
-type CallbackStream = ::stream::ServiceStream<BrowseResult>;
+type CallbackStream = crate::stream::ServiceStream<BrowseResult>;
 
 bitflags! {
 	/// Flags for [`BrowseResult`](struct.BrowseResult.html)
@@ -73,8 +73,8 @@ impl BrowseResult {
 	///
 	/// Should check before whether result has the `Add` flag, as
 	/// otherwise it probably won't find anything.
-	pub fn resolve(&self) -> io::Result<::Resolve> {
-		::resolve(
+	pub fn resolve(&self) -> io::Result<crate::Resolve> {
+		crate::resolve(
 			self.interface,
 			&self.service_name,
 			&self.reg_type,
@@ -144,7 +144,7 @@ pub fn browse_extended(
 	reg_type: &str,
 	data: BrowseData,
 ) -> io::Result<Browse> {
-	::init();
+	crate::init();
 
 	let reg_type = cstr::CStr::from(&reg_type)?;
 	let domain = cstr::NullableCStr::from(&data.domain)?;

--- a/src/service/browse.rs
+++ b/src/service/browse.rs
@@ -1,3 +1,4 @@
+use bitflags::bitflags;
 use futures::{
 	self,
 	Async,
@@ -142,7 +143,7 @@ impl<'a> Default for BrowseData<'a> {
 /// See [`DNSServiceBrowse`](https://developer.apple.com/documentation/dnssd/1804742-dnsservicebrowse).
 pub fn browse_extended(
 	reg_type: &str,
-	data: BrowseData,
+	data: BrowseData<'_>,
 ) -> io::Result<Browse> {
 	crate::init();
 

--- a/src/service/connection.rs
+++ b/src/service/connection.rs
@@ -1,3 +1,4 @@
+use bitflags::bitflags;
 use futures::{
 	self,
 	Async,

--- a/src/service/connection.rs
+++ b/src/service/connection.rs
@@ -9,17 +9,17 @@ use std::{
 	rc::Rc,
 };
 
-use cstr;
-use dns_consts::{
+use crate::cstr;
+use crate::dns_consts::{
 	Class,
 	Type,
 };
-use evented::EventedDNSService;
-use ffi;
-use interface::Interface;
-use raw;
+use crate::evented::EventedDNSService;
+use crate::ffi;
+use crate::interface::Interface;
+use crate::raw;
 
-type CallbackFuture = ::future::ServiceFutureSingle<RegisterRecordResult>;
+type CallbackFuture = crate::future::ServiceFutureSingle<RegisterRecordResult>;
 
 /// Connection to register records with
 pub struct Connection(Rc<EventedDNSService>);
@@ -29,7 +29,7 @@ pub struct Connection(Rc<EventedDNSService>);
 ///
 /// See [`DNSServiceCreateConnection`](https://developer.apple.com/documentation/dnssd/1804724-dnsservicecreateconnection).
 pub fn connect() -> io::Result<Connection> {
-	::init();
+	crate::init();
 
 	let con = raw::DNSService::create_connection()?;
 	Ok(Connection(Rc::new(EventedDNSService::new(con)?)))
@@ -58,11 +58,11 @@ bitflags! {
 // the future gets canceled by dropping the record; must
 // not drop the future without dropping the record.
 #[must_use = "futures do nothing unless polled"]
-pub struct RegisterRecord(CallbackFuture, Option<::Record>);
+pub struct RegisterRecord(CallbackFuture, Option<crate::Record>);
 
 impl futures::Future for RegisterRecord {
 	type Error = io::Error;
-	type Item = ::Record;
+	type Item = crate::Record;
 
 	fn poll(&mut self) -> Result<Async<Self::Item>, Self::Error> {
 		match self.0.poll() {
@@ -181,7 +181,7 @@ impl Connection {
 }
 
 impl RegisterRecord {
-	fn record(&self) -> &::Record {
+	fn record(&self) -> &crate::Record {
 		self.1.as_ref().expect("RegisterRecord future is done")
 	}
 

--- a/src/service/enumerate_domains.rs
+++ b/src/service/enumerate_domains.rs
@@ -1,3 +1,4 @@
+use bitflags::bitflags;
 use futures::{
 	self,
 	Async,

--- a/src/service/enumerate_domains.rs
+++ b/src/service/enumerate_domains.rs
@@ -10,12 +10,12 @@ use std::{
 	},
 };
 
-use cstr;
-use ffi;
-use interface::Interface;
-use raw;
+use crate::cstr;
+use crate::ffi;
+use crate::interface::Interface;
+use crate::raw;
 
-type CallbackStream = ::stream::ServiceStream<EnumerateResult>;
+type CallbackStream = crate::stream::ServiceStream<EnumerateResult>;
 
 /// Whether to enumerate domains which are browsed or domains for which
 /// registrations can be made.
@@ -111,7 +111,7 @@ pub fn enumerate_domains(
 	enumerate: Enumerate,
 	interface: Interface,
 ) -> io::Result<EnumerateDomains> {
-	::init();
+	crate::init();
 
 	Ok(EnumerateDomains(CallbackStream::new(
 		move |sender| {

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -18,7 +18,7 @@ mod register;
 mod resolve;
 mod resolve_host;
 
-use dns_consts::{
+use crate::dns_consts::{
 	Class,
 	Type,
 };
@@ -27,16 +27,16 @@ use dns_consts::{
 ///
 /// See [`DNSServiceReconfirmRecord`](https://developer.apple.com/documentation/dnssd/1804726-dnsservicereconfirmrecord).
 pub fn reconfirm_record(
-	interface: ::interface::Interface,
+	interface: crate::interface::Interface,
 	fullname: &str,
 	rr_type: Type,
 	rr_class: Class,
 	rdata: &[u8],
 ) -> ::std::io::Result<()> {
-	::init();
+	crate::init();
 
-	let fullname = ::cstr::CStr::from(&fullname)?;
-	::raw::reconfirm_record(
+	let fullname = crate::cstr::CStr::from(&fullname)?;
+	crate::raw::reconfirm_record(
 		0, // no flags
 		interface.into_raw(),
 		&fullname,
@@ -65,15 +65,15 @@ impl<'a> FullName<'a> {
 	pub fn construct(&self) -> ::std::io::Result<String> {
 		use std::io;
 
-		let service = ::cstr::NullableCStr::from(&self.service)?;
-		let reg_type = ::cstr::CStr::from(&self.reg_type)?;
-		let domain = ::cstr::CStr::from(&self.domain)?;
+		let service = crate::cstr::NullableCStr::from(&self.service)?;
+		let reg_type = crate::cstr::CStr::from(&self.reg_type)?;
+		let domain = crate::cstr::CStr::from(&self.domain)?;
 
-		const SIZE: usize = ::ffi::MAX_DOMAIN_NAME + 200;
+		const SIZE: usize = crate::ffi::MAX_DOMAIN_NAME + 200;
 		let mut buf: Vec<u8> = Vec::new();
 		buf.reserve(SIZE);
 		let len = unsafe {
-			::ffi::DNSServiceConstructFullName(
+			crate::ffi::DNSServiceConstructFullName(
 				buf.as_mut_ptr() as *mut i8,
 				service.as_ptr(),
 				reg_type.as_ptr(),

--- a/src/service/query_record.rs
+++ b/src/service/query_record.rs
@@ -1,3 +1,4 @@
+use bitflags::bitflags;
 use futures::{
 	self,
 	Async,

--- a/src/service/query_record.rs
+++ b/src/service/query_record.rs
@@ -10,16 +10,16 @@ use std::{
 	},
 };
 
-use cstr;
-use dns_consts::{
+use crate::cstr;
+use crate::dns_consts::{
 	Class,
 	Type,
 };
-use ffi;
-use interface::Interface;
-use raw;
+use crate::ffi;
+use crate::interface::Interface;
+use crate::raw;
 
-type CallbackStream = ::stream::ServiceStream<QueryRecordResult>;
+type CallbackStream = crate::stream::ServiceStream<QueryRecordResult>;
 
 bitflags! {
 	/// Flags used to query for a record
@@ -153,7 +153,7 @@ pub fn query_record_extended(
 	rr_type: Type,
 	data: QueryRecordData,
 ) -> io::Result<QueryRecord> {
-	::init();
+	crate::init();
 
 	let fullname = cstr::CStr::from(&fullname)?;
 

--- a/src/service/records.rs
+++ b/src/service/records.rs
@@ -1,7 +1,7 @@
 use std::io;
 
-use dns_consts::Type;
-use raw;
+use crate::dns_consts::Type;
+use crate::raw;
 
 /// A successful record registration
 ///

--- a/src/service/register.rs
+++ b/src/service/register.rs
@@ -10,14 +10,14 @@ use std::{
 	},
 };
 
-use cstr;
-use dns_consts::Type;
-use evented::EventedDNSService;
-use ffi;
-use interface::Interface;
-use raw;
+use crate::cstr;
+use crate::dns_consts::Type;
+use crate::evented::EventedDNSService;
+use crate::ffi;
+use crate::interface::Interface;
+use crate::raw;
 
-type CallbackFuture = ::future::ServiceFuture<RegisterResult>;
+type CallbackFuture = crate::future::ServiceFuture<RegisterResult>;
 
 bitflags! {
 	/// Flags used to register service
@@ -57,7 +57,7 @@ impl Registration {
 		rr_type: Type,
 		rdata: &[u8],
 		ttl: u32,
-	) -> io::Result<::Record> {
+	) -> io::Result<crate::Record> {
 		Ok(self
 			.0
 			.service()
@@ -70,7 +70,7 @@ impl Registration {
 	///
 	/// [`Record::keep`](struct.Record.html#method.keep) doesn't do
 	/// anything useful on that handle.
-	pub fn get_default_txt_record(&self) -> ::Record {
+	pub fn get_default_txt_record(&self) -> crate::Record {
 		self.0.service().get_default_txt_record().into()
 	}
 }
@@ -91,7 +91,7 @@ impl Register {
 		rr_type: Type,
 		rdata: &[u8],
 		ttl: u32,
-	) -> io::Result<::Record> {
+	) -> io::Result<crate::Record> {
 		Ok(self
 			.0
 			.service()
@@ -104,7 +104,7 @@ impl Register {
 	///
 	/// [`Record::keep`](struct.Record.html#method.keep) doesn't do
 	/// anything useful on that handle.
-	pub fn get_default_txt_record(&self) -> ::Record {
+	pub fn get_default_txt_record(&self) -> crate::Record {
 		self.0.service().get_default_txt_record().into()
 	}
 }
@@ -227,7 +227,7 @@ pub fn register_extended(
 	port: u16,
 	data: RegisterData,
 ) -> io::Result<Register> {
-	::init();
+	crate::init();
 
 	let name = cstr::NullableCStr::from(&data.name)?;
 	let reg_type = cstr::CStr::from(&reg_type)?;

--- a/src/service/register.rs
+++ b/src/service/register.rs
@@ -1,3 +1,4 @@
+use bitflags::bitflags;
 use futures::{
 	self,
 	Async,
@@ -225,7 +226,7 @@ impl<'a> Default for RegisterData<'a> {
 pub fn register_extended(
 	reg_type: &str,
 	port: u16,
-	data: RegisterData,
+	data: RegisterData<'_>,
 ) -> io::Result<Register> {
 	crate::init();
 

--- a/src/service/resolve.rs
+++ b/src/service/resolve.rs
@@ -10,17 +10,17 @@ use std::{
 	},
 };
 
-use cstr;
-use ffi;
-use interface::Interface;
-use raw;
-use service::{
+use crate::cstr;
+use crate::ffi;
+use crate::interface::Interface;
+use crate::raw;
+use crate::service::{
 	ResolveHost,
 	ResolveHostData,
 	resolve_host_extended,
 };
 
-type CallbackStream = ::stream::ServiceStream<ResolveResult>;
+type CallbackStream = crate::stream::ServiceStream<ResolveResult>;
 
 /// Pending resolve request
 #[must_use = "streams do nothing unless polled"]
@@ -105,7 +105,7 @@ pub fn resolve(
 	reg_type: &str,
 	domain: &str,
 ) -> io::Result<Resolve> {
-	::init();
+	crate::init();
 
 	let name = cstr::CStr::from(&name)?;
 	let reg_type = cstr::CStr::from(&reg_type)?;

--- a/src/service/resolve_host.rs
+++ b/src/service/resolve_host.rs
@@ -14,6 +14,7 @@ use futures::{
 	Poll,
 	Stream,
 	stream,
+	try_ready,
 };
 
 use crate::dns_consts::{
@@ -160,7 +161,7 @@ impl Into<SocketAddrV6> for ScopedSocketAddr {
 }
 
 impl fmt::Display for ScopedSocketAddr {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		match self {
 			ScopedSocketAddr::V4 { address, port, scope_id: 0 } => {
 				write!(f, "{}:{}", address, port)
@@ -179,7 +180,7 @@ impl fmt::Display for ScopedSocketAddr {
 }
 
 impl fmt::Debug for ScopedSocketAddr {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		fmt::Display::fmt(self, f)
 	}
 }

--- a/src/service/resolve_host.rs
+++ b/src/service/resolve_host.rs
@@ -16,18 +16,18 @@ use futures::{
 	stream,
 };
 
-use dns_consts::{
+use crate::dns_consts::{
 	Class,
 	Type,
 };
-use service::{
+use crate::service::{
 	QueryRecord,
 	QueryRecordData,
 	QueryRecordFlags,
 	QueryRecordResult,
 	query_record_extended,
 };
-use interface::Interface;
+use crate::interface::Interface;
 
 fn decode_a(a: QueryRecordResult) -> Option<(IpAddr, Interface)> {
 	if a.rr_class == Class::IN && a.rr_type == Type::A && a.rdata.len() == 4 {

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -8,10 +8,10 @@ use std::{
 	os::raw::c_void,
 };
 
-use error::Error;
-use evented::EventedDNSService;
-use ffi;
-use raw::DNSService;
+use crate::error::Error;
+use crate::evented::EventedDNSService;
+use crate::ffi;
+use crate::raw::DNSService;
 
 #[allow(clippy::borrowed_box)]
 fn box_raw<T>(ptr: &mut Box<T>) -> *mut c_void {

--- a/src/txt_record.rs
+++ b/src/txt_record.rs
@@ -109,7 +109,7 @@ impl TxtRecord {
 		}
 	}
 
-	fn _position_keys(&self) -> PositionKeyIter {
+	fn _position_keys(&self) -> PositionKeyIter<'_> {
 		PositionKeyIter {
 			pos: 0,
 			data: &self.0,
@@ -117,7 +117,7 @@ impl TxtRecord {
 	}
 
 	/// Iterate over all `(key, value)` pairs.
-	pub fn iter(&self) -> TxtRecordIter {
+	pub fn iter(&self) -> TxtRecordIter<'_> {
 		TxtRecordIter {
 			pos: 0,
 			data: &self.0,


### PR DESCRIPTION
This migrates the crate to Rust 2018 edition.

Most of the changes are done automatically via
```bash
cargo fix --edition
cargo fix --edition-idioms
```

There are some manual changes mainly for replacing `#[macro_use] extern crate` with `use` macro name.