### PR TITLE
Mark callbacks unsafe

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -105,7 +105,7 @@ DNSServiceError: i32 =>
 }
 
 pub type DNSServiceDomainEnumReply = Option<
-	extern "C" fn(
+	unsafe extern "C" fn(
 		sd_ref: DNSServiceRef,
 		flags: DNSServiceFlags,
 		interface_index: u32,
@@ -115,7 +115,7 @@ pub type DNSServiceDomainEnumReply = Option<
 	),
 >;
 pub type DNSServiceRegisterReply = Option<
-	extern "C" fn(
+	unsafe extern "C" fn(
 		sd_ref: DNSServiceRef,
 		flags: DNSServiceFlags,
 		error_code: DNSServiceErrorType,
@@ -126,7 +126,7 @@ pub type DNSServiceRegisterReply = Option<
 	),
 >;
 pub type DNSServiceBrowseReply = Option<
-	extern "C" fn(
+	unsafe extern "C" fn(
 		sd_ref: DNSServiceRef,
 		flags: DNSServiceFlags,
 		interface_index: u32,
@@ -138,7 +138,7 @@ pub type DNSServiceBrowseReply = Option<
 	),
 >;
 pub type DNSServiceResolveReply = Option<
-	extern "C" fn(
+	unsafe extern "C" fn(
 		sd_ref: DNSServiceRef,
 		flags: DNSServiceFlags,
 		interface_index: u32,
@@ -152,7 +152,7 @@ pub type DNSServiceResolveReply = Option<
 	),
 >;
 pub type DNSServiceRegisterRecordReply = Option<
-	extern "C" fn(
+	unsafe extern "C" fn(
 		sd_ref: DNSServiceRef,
 		record_ref: DNSRecordRef,
 		flags: DNSServiceFlags,
@@ -161,7 +161,7 @@ pub type DNSServiceRegisterRecordReply = Option<
 	),
 >;
 pub type DNSServiceQueryRecordReply = Option<
-	extern "C" fn(
+	unsafe extern "C" fn(
 		sd_ref: DNSServiceRef,
 		flags: DNSServiceFlags,
 		interface_index: u32,

--- a/src/service/browse.rs
+++ b/src/service/browse.rs
@@ -83,7 +83,7 @@ impl BrowseResult {
 	}
 }
 
-extern "C" fn browse_callback(
+unsafe extern "C" fn browse_callback(
 	_sd_ref: ffi::DNSServiceRef,
 	flags: ffi::DNSServiceFlags,
 	interface_index: u32,
@@ -94,9 +94,9 @@ extern "C" fn browse_callback(
 	context: *mut c_void,
 ) {
 	CallbackStream::run_callback(context, error_code, || {
-		let service_name = unsafe { cstr::from_cstr(service_name) }?;
-		let reg_type = unsafe { cstr::from_cstr(reg_type) }?;
-		let reply_domain = unsafe { cstr::from_cstr(reply_domain) }?;
+		let service_name = cstr::from_cstr(service_name)?;
+		let reg_type = cstr::from_cstr(reg_type)?;
+		let reply_domain = cstr::from_cstr(reply_domain)?;
 
 		Ok(BrowseResult {
 			flags: BrowsedFlags::from_bits_truncate(flags),

--- a/src/service/enumerate_domains.rs
+++ b/src/service/enumerate_domains.rs
@@ -85,7 +85,7 @@ pub struct EnumerateResult {
 	pub domain: String,
 }
 
-extern "C" fn enumerate_callback(
+unsafe extern "C" fn enumerate_callback(
 	_sd_ref: ffi::DNSServiceRef,
 	flags: ffi::DNSServiceFlags,
 	interface_index: u32,
@@ -94,7 +94,7 @@ extern "C" fn enumerate_callback(
 	context: *mut c_void,
 ) {
 	CallbackStream::run_callback(context, error_code, || {
-		let reply_domain = unsafe { cstr::from_cstr(reply_domain) }?;
+		let reply_domain = cstr::from_cstr(reply_domain)?;
 
 		Ok(EnumerateResult {
 			flags: EnumeratedFlags::from_bits_truncate(flags),

--- a/src/service/query_record.rs
+++ b/src/service/query_record.rs
@@ -84,7 +84,7 @@ pub struct QueryRecordResult {
 	pub ttl: u32,
 }
 
-extern "C" fn query_record_callback(
+unsafe extern "C" fn query_record_callback(
 	_sd_ref: ffi::DNSServiceRef,
 	flags: ffi::DNSServiceFlags,
 	interface_index: u32,
@@ -98,9 +98,8 @@ extern "C" fn query_record_callback(
 	context: *mut c_void,
 ) {
 	CallbackStream::run_callback(context, error_code, || {
-		let fullname = unsafe { cstr::from_cstr(fullname) }?;
-		let rdata =
-			unsafe { ::std::slice::from_raw_parts(rdata, rd_len as usize) };
+		let fullname = cstr::from_cstr(fullname)?;
+		let rdata = ::std::slice::from_raw_parts(rdata, rd_len as usize);
 
 		Ok(QueryRecordResult {
 			flags: QueriedRecordFlags::from_bits_truncate(flags),

--- a/src/service/register.rs
+++ b/src/service/register.rs
@@ -139,7 +139,7 @@ pub struct RegisterResult {
 	pub domain: String,
 }
 
-extern "C" fn register_callback(
+unsafe extern "C" fn register_callback(
 	_sd_ref: ffi::DNSServiceRef,
 	_flags: ffi::DNSServiceFlags,
 	error_code: ffi::DNSServiceErrorType,
@@ -149,9 +149,9 @@ extern "C" fn register_callback(
 	context: *mut c_void,
 ) {
 	CallbackFuture::run_callback(context, error_code, || {
-		let name = unsafe { cstr::from_cstr(name) }?;
-		let reg_type = unsafe { cstr::from_cstr(reg_type) }?;
-		let domain = unsafe { cstr::from_cstr(domain) }?;
+		let name = cstr::from_cstr(name)?;
+		let reg_type = cstr::from_cstr(reg_type)?;
+		let domain = cstr::from_cstr(domain)?;
 
 		Ok(RegisterResult {
 			name: name.to_string(),

--- a/src/service/resolve.rs
+++ b/src/service/resolve.rs
@@ -63,7 +63,7 @@ impl ResolveResult {
 	}
 }
 
-extern "C" fn resolve_callback(
+unsafe extern "C" fn resolve_callback(
 	_sd_ref: ffi::DNSServiceRef,
 	_flags: ffi::DNSServiceFlags,
 	interface_index: u32,
@@ -76,11 +76,9 @@ extern "C" fn resolve_callback(
 	context: *mut c_void,
 ) {
 	CallbackStream::run_callback(context, error_code, || {
-		let fullname = unsafe { cstr::from_cstr(fullname) }?;
-		let host_target = unsafe { cstr::from_cstr(host_target) }?;
-		let txt = unsafe {
-			::std::slice::from_raw_parts(txt_record, txt_len as usize)
-		};
+		let fullname = cstr::from_cstr(fullname)?;
+		let host_target = cstr::from_cstr(host_target)?;
+		let txt = ::std::slice::from_raw_parts(txt_record, txt_len as usize);
 
 		Ok(ResolveResult {
 			interface: Interface::from_raw(interface_index),


### PR DESCRIPTION
Those callbacks are only safe if the pointers passed in are valid, thus they should be unsafe, otherwise you would be able to trigger undefined behavior in safe Rust code via passing e.g. `ptr::null()` for the pointers.