### PR TITLE
encapsulate fd_set

### DIFF
--- a/src/evented/windows.rs
+++ b/src/evented/windows.rs
@@ -30,6 +30,9 @@ use std::{
 	thread,
 	time::Duration,
 };
+use winapi::um::winsock2;
+
+use self::fd_set::FdSet;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 enum PollRequest {
@@ -39,33 +42,30 @@ enum PollRequest {
 
 struct SelectFdRead {
 	fd: c_int,
-	read_fds: libc::fd_set,
+	read_fds: FdSet,
 }
 impl SelectFdRead {
 	pub fn new(fd: c_int) -> Self {
-		use std::mem::uninitialized;
-		let mut read_fds: libc::fd_set = unsafe { uninitialized() };
-		unsafe { libc::FD_ZERO(&mut read_fds) };
-		SelectFdRead { fd, read_fds }
+		SelectFdRead { fd, read_fds: FdSet::new() }
 	}
 
 	pub fn select(&mut self, timeout: Option<Duration>) -> bool {
 		use std::ptr::null_mut;
-		let mut timeout = timeout.map(|timeout| libc::timeval {
+		let mut timeout = timeout.map(|timeout| winsock2::timeval {
 			tv_sec: timeout.as_secs() as libc::c_long,
 			tv_usec: (timeout.subsec_nanos() / 1000) as libc::c_long,
 		});
+		self.read_fds.set(self.fd);
 		unsafe {
-			libc::FD_SET(self.fd, &mut self.read_fds);
-			libc::select(
+			winsock2::select(
 				self.fd + 1,
-				&mut self.read_fds,
+				self.read_fds.inner(),
 				null_mut(),
 				null_mut(),
 				timeout.as_mut().map(|x| x as *mut _).unwrap_or(null_mut()),
 			);
-			libc::FD_ISSET(self.fd, &mut self.read_fds)
 		}
+		self.read_fds.is_set(self.fd)
 	}
 }
 
@@ -226,49 +226,43 @@ impl Drop for PollReadFd {
 	}
 }
 
-#[cfg(windows)]
-mod libc {
-	pub use libc::{
-		c_int,
-		c_long,
-		c_uint,
-	};
-	pub use winapi::um::winsock2::{
-		fd_set,
-		select,
-		timeval,
+mod fd_set {
+	use libc::{c_int, c_uint};
+	use winapi::um::winsock2::{
+		fd_set as RawFdSet,
 		FD_SETSIZE,
 		SOCKET,
 	};
 
-	#[allow(non_snake_case)]
-	pub unsafe fn FD_ZERO(set: *mut fd_set) {
-		let set = &mut *set;
-		set.fd_count = 0;
-	}
+	pub(super) struct FdSet(RawFdSet);
 
-	#[allow(non_snake_case)]
-	pub unsafe fn FD_SET(fd: c_int, set: *mut fd_set) {
-		if FD_ISSET(fd, set) {
-			return;
+	impl FdSet {
+		pub fn new() -> Self {
+			FdSet(RawFdSet {
+				fd_count: 0,
+				fd_array: [0; FD_SETSIZE],
+			})
 		}
-		let set = &mut *set;
-		let fd = fd as c_uint as SOCKET;
-		if (set.fd_count as usize) < FD_SETSIZE {
-			set.fd_array[set.fd_count as usize] = fd;
-			set.fd_count += 1;
-		}
-	}
 
-	#[allow(non_snake_case)]
-	pub unsafe fn FD_ISSET(fd: c_int, set: *mut fd_set) -> bool {
-		let set = &mut *set;
-		let fd = fd as c_uint as SOCKET;
-		set.fd_array[..set.fd_count as usize]
-			.iter()
-			.any(|i| *i == fd)
+		pub fn inner(&mut self) -> *mut RawFdSet {
+			&mut self.0
+		}
+
+		pub fn set(&mut self, fd: c_int) {
+			if self.is_set(fd) {
+				return;
+			}
+			let count = self.0.fd_count as usize;
+			if count < FD_SETSIZE {
+				self.0.fd_array[count] = fd as c_uint as SOCKET;
+				self.0.fd_count += 1;
+			}
+		}
+
+		pub fn is_set(&self, fd: c_int) -> bool {
+			let fd = fd as c_uint as SOCKET;
+			let count = self.0.fd_count as usize;
+			self.0.fd_array[..count].iter().any(|i| *i == fd)
+		}
 	}
 }
-
-#[cfg(unix)]
-use libc;

--- a/src/evented/windows.rs
+++ b/src/evented/windows.rs
@@ -234,38 +234,76 @@ mod fd_set {
 		SOCKET,
 	};
 	use std::mem::MaybeUninit;
+	use std::ptr;
 
-	pub(super) struct FdSet(RawFdSet);
+	/// Layout compatible struct of `fd_set`, but it holds maybe uninitialized `fd_array`.
+	///
+	/// # Safety
+	/// The first `fd_count` slots of `fd_array` must be initialized,
+	/// and the rest must be uninitialized.
+	#[repr(C)]
+	pub(super) struct FdSet {
+		fd_count: u32,
+		fd_array: [MaybeUninit<SOCKET>; FD_SETSIZE],
+	}
 
 	impl FdSet {
 		pub fn new() -> Self {
-			let fd_count = 0;
-			// This is safe because we don't read from it when the slot is not initialized.
-			let fd_array = [unsafe {
-				MaybeUninit::<usize>::uninit().assume_init()
-			}; FD_SETSIZE];
-			FdSet(RawFdSet { fd_count, fd_array })
+			FdSet {
+				fd_count: 0,
+				fd_array: [MaybeUninit::uninit(); FD_SETSIZE],
+			}
 		}
 
 		pub fn inner(&mut self) -> *mut RawFdSet {
-			&mut self.0
+			self as *mut FdSet as *mut _
 		}
 
 		pub fn set(&mut self, fd: c_int) {
 			if self.is_set(fd) {
 				return;
 			}
-			let count = self.0.fd_count as usize;
+			let count = self.fd_count as usize;
 			if count < FD_SETSIZE {
-				self.0.fd_array[count] = fd as c_uint as SOCKET;
-				self.0.fd_count += 1;
+				let fd = fd as c_uint as SOCKET;
+				// This is safe because this slot is uninitialized.
+				unsafe { ptr::write(self.fd_array[count].as_mut_ptr(), fd) };
+				self.fd_count += 1;
 			}
 		}
 
 		pub fn is_set(&self, fd: c_int) -> bool {
 			let fd = fd as c_uint as SOCKET;
-			let count = self.0.fd_count as usize;
-			self.0.fd_array[..count].iter().any(|i| *i == fd)
+			let count = self.fd_count as usize;
+			self.fd_array[..count].iter().any(|slot| {
+				// This is safe because it's reading from first `fd_count` slots.
+				fd == unsafe { ptr::read(slot.as_ptr()) }
+			})
+		}
+	}
+
+	#[cfg(test)]
+	mod tests {
+		use super::*;
+		use std::mem::{needs_drop, transmute};
+
+		// Check that `FdSet` is layout compatible with `fd_set`.
+		#[test]
+		fn fd_set_layout_compatible() {
+			let mut fd_set = FdSet::new();
+			(0..FD_SETSIZE as c_int).for_each(|i| fd_set.set(i));
+			let fd_set: RawFdSet = unsafe { transmute(fd_set) };
+			assert_eq!(fd_set.fd_count, FD_SETSIZE as u32);
+			for i in 0..FD_SETSIZE as usize {
+				assert_eq!(fd_set.fd_array[i], i as SOCKET);
+			}
+		}
+
+		// Check that `SOCKET` doesn't need to be dropped, so that we don't need to
+		// implement `Drop` for `FdSet`.
+		#[test]
+		fn socket_not_drop() {
+			assert!(!needs_drop::<SOCKET>());
 		}
 	}
 }

--- a/src/evented/windows.rs
+++ b/src/evented/windows.rs
@@ -233,15 +233,18 @@ mod fd_set {
 		FD_SETSIZE,
 		SOCKET,
 	};
+	use std::mem::MaybeUninit;
 
 	pub(super) struct FdSet(RawFdSet);
 
 	impl FdSet {
 		pub fn new() -> Self {
-			FdSet(RawFdSet {
-				fd_count: 0,
-				fd_array: [0; FD_SETSIZE],
-			})
+			let fd_count = 0;
+			// This is safe because we don't read from it when the slot is not initialized.
+			let fd_array = [unsafe {
+				MaybeUninit::<usize>::uninit().assume_init()
+			}; FD_SETSIZE];
+			FdSet(RawFdSet { fd_count, fd_array })
 		}
 
 		pub fn inner(&mut self) -> *mut RawFdSet {


### PR DESCRIPTION
This encapsulates `fd_set` into a type `FdSet` providing a safe API to use.

It replaces deprecated `uninitialized()` with `MaybeUninit`. It isn't clear that this `assume_init` is fully safe, but it's not worse than before anyway.