### PR TITLE
windows PollReadFd: Don't unwrap if the other end was dropped

### DIFF
--- a/src/evented/windows.rs
+++ b/src/evented/windows.rs
@@ -199,7 +199,8 @@ impl PollReadFd {
 
 				debug!("[select thread] read event");
 
-				futures::executor::block_on(send_response.send(())).unwrap();
+                                // Can only fail if the other end is dropped
+				let _ = futures::executor::block_on(send_response.send(()));
 			}
 		});
 


### PR DESCRIPTION
The only way this send can fail is if the other end was dropped.  This thread runs select with 1s timeouts and checks if it should close in between.  If a close message was sent in the same second that the select returned, then we could miss the message and try to send anyway, leading to an error.  Since we don't care about this error, don't unwrap it.  This could also be fixed by checking `recv_request` after leaving the select loop, but this is simpler.