### PR TITLE
Split up futures dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,18 @@ pkg-config = "0.3.9"
 
 [dependencies]
 bitflags = "1.0.4"
-futures = "0.3.1"
+futures-core = "0.3.1"
+futures-channel = "0.3.1"
+futures-util = { version = "0.3.1", default-features = false, features = ["std"] }
 libc = "0.2.65"
 log = "0.4.8"
 mio = "0.6.21"
-pin-utils = "0.1.0-alpha.4"
-tokio = { version = "0.2.4", features = ["time", "io-driver", "rt-util", "macros", "rt-core"] }
+pin-utils = "0.1.0"
+tokio = { version = "0.2.4", features = ["time", "io-driver", "rt-core"] }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.6", features = ["winsock2"] }
+
+[dev-dependencies]
+futures = "0.3.1"
+tokio = { version = "0.2.4", features = ["macros"] }

--- a/src/evented/unix.rs
+++ b/src/evented/unix.rs
@@ -1,3 +1,4 @@
+use futures_core::ready;
 use std::{
 	io,
 	os::raw::c_int,
@@ -38,7 +39,7 @@ impl PollReadFd {
 	}
 
 	pub fn poll_read_ready(&self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-		if futures::ready!(self.0.poll_read_ready(cx, mio::Ready::readable()))?.is_readable() {
+		if ready!(self.0.poll_read_ready(cx, mio::Ready::readable()))?.is_readable() {
 			Poll::Ready(Ok(()))
 		} else {
 			Poll::Pending

--- a/src/future.rs
+++ b/src/future.rs
@@ -1,8 +1,8 @@
-use futures::{
-	channel::oneshot,
-	prelude::*,
-};
+use futures_channel::oneshot;
+use futures_core::ready;
+use futures_util::FutureExt;
 use std::{
+	future::Future,
 	io,
 	os::raw::c_void,
 	pin::Pin,
@@ -111,8 +111,7 @@ impl<S: EventedService, T> Future for ServiceFuture<S, T> {
 			return Poll::Pending;
 		}
 		self.inner_mut().service.poll(cx)?;
-		let item =
-			futures::ready!(self.inner_mut().receiver.poll_unpin(cx)).expect("send can't die")?;
+		let item = ready!(self.inner_mut().receiver.poll_unpin(cx)).expect("send can't die")?;
 		Poll::Ready(Ok((self.0.take().unwrap().service, item)))
 	}
 }

--- a/src/inner.rs
+++ b/src/inner.rs
@@ -1,11 +1,9 @@
 #![allow(clippy::too_many_arguments)]
 
-use futures::{
-	lock,
-	prelude::*,
-};
+use futures_util::lock;
 use libc::c_void;
 use std::{
+	future::Future,
 	io,
 	pin::Pin,
 	ptr::null_mut,

--- a/src/service/browse.rs
+++ b/src/service/browse.rs
@@ -1,4 +1,4 @@
-use futures::{self,};
+use futures_core::Stream;
 use std::{
 	io,
 	os::raw::{
@@ -51,7 +51,7 @@ impl Browse {
 	pin_utils::unsafe_pinned!(stream: CallbackStream);
 }
 
-impl futures::Stream for Browse {
+impl Stream for Browse {
 	type Item = io::Result<BrowseResult>;
 
 	fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {

--- a/src/service/connection.rs
+++ b/src/service/connection.rs
@@ -1,5 +1,7 @@
-use futures::prelude::*;
+use futures_core::ready;
+use futures_util::FutureExt;
 use std::{
+	future::Future,
 	io,
 	os::raw::c_void,
 	pin::Pin,
@@ -73,7 +75,7 @@ impl Future for RegisterRecord {
 	type Output = io::Result<crate::Record>;
 
 	fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-		futures::ready!(self.as_mut().future().poll(cx))?;
+		ready!(self.as_mut().future().poll(cx))?;
 		Poll::Ready(Ok(self.record().take().unwrap()))
 	}
 }

--- a/src/service/enumerate_domains.rs
+++ b/src/service/enumerate_domains.rs
@@ -1,4 +1,4 @@
-use futures::{self,};
+use futures_core::Stream;
 use std::{
 	io,
 	os::raw::{
@@ -73,7 +73,7 @@ impl EnumerateDomains {
 	pin_utils::unsafe_pinned!(stream: CallbackStream);
 }
 
-impl futures::Stream for EnumerateDomains {
+impl Stream for EnumerateDomains {
 	type Item = io::Result<EnumerateResult>;
 
 	fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {

--- a/src/service/query_record.rs
+++ b/src/service/query_record.rs
@@ -1,4 +1,4 @@
-use futures::{self,};
+use futures_core::Stream;
 use std::{
 	io,
 	os::raw::{
@@ -64,7 +64,7 @@ impl QueryRecord {
 	pin_utils::unsafe_pinned!(stream: CallbackStream);
 }
 
-impl futures::Stream for QueryRecord {
+impl Stream for QueryRecord {
 	type Item = io::Result<QueryRecordResult>;
 
 	fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {

--- a/src/service/register.rs
+++ b/src/service/register.rs
@@ -1,4 +1,6 @@
+use futures_core::ready;
 use std::{
+	future::Future,
 	io,
 	os::raw::{
 		c_char,
@@ -110,11 +112,11 @@ impl Register {
 	}
 }
 
-impl futures::Future for Register {
+impl Future for Register {
 	type Output = io::Result<(Registration, RegisterResult)>;
 
 	fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-		let (service, item) = futures::ready!(self.future().poll(cx))?;
+		let (service, item) = ready!(self.future().poll(cx))?;
 		Poll::Ready(Ok((Registration(service), item)))
 	}
 }

--- a/src/service/resolve.rs
+++ b/src/service/resolve.rs
@@ -1,4 +1,5 @@
-use futures::{self,};
+use futures_core::Stream;
+
 use std::{
 	io,
 	os::raw::{
@@ -48,7 +49,7 @@ impl Resolve {
 	pin_utils::unsafe_pinned!(stream: CallbackStream);
 }
 
-impl futures::Stream for Resolve {
+impl Stream for Resolve {
 	type Item = io::Result<ResolveResult>;
 
 	fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {

--- a/src/service/resolve_host.rs
+++ b/src/service/resolve_host.rs
@@ -16,10 +16,11 @@ use std::{
 	},
 };
 
-use futures::{
-	prelude::*,
+use futures_core::Stream;
+use futures_util::{
 	stream,
-	Stream,
+	StreamExt,
+	TryStreamExt,
 };
 
 use crate::{

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,7 +1,6 @@
-use futures::{
-	channel::mpsc,
-	prelude::*,
-};
+use futures_channel::mpsc;
+use futures_core::Stream;
+use futures_util::StreamExt;
 use std::{
 	io,
 	os::raw::c_void,

--- a/src/timeout_stream.rs
+++ b/src/timeout_stream.rs
@@ -1,4 +1,8 @@
-use futures::prelude::*;
+use futures_core::{
+	Stream,
+	TryStream,
+};
+use futures_util::FutureExt;
 use std::{
 	io,
 	pin::Pin,


### PR DESCRIPTION
Splits up the `futures` dependency into `futures-core`, `futures-util` and `futures-channel`. Furthermore, some dependencies were moved to dev-dependencies. 

This reduces the number of dependencies, especially all proc-macro dependencies, and thus reduces the compile time from 14.5s to 7.5s on my laptop. (If you compile it directly, it has only effect with `cargo +nightly -Zfeatures=dev_dep build`, but dependent crates will benefit without it.)