### PR TITLE
Fix for Windows compilation error

### DIFF
--- a/src/evented/windows.rs
+++ b/src/evented/windows.rs
@@ -15,7 +15,7 @@
 //! back to a smaller timeout.
 
 use futures_channel::mpsc as futures_mpsc;
-use futures_util::StreamExt;
+use futures_util::{SinkExt, StreamExt};
 use log::debug;
 use std::{
 	io,


### PR DESCRIPTION
This fixes the build when compiling on Windows, addressing the following error in \evented\windows.rs:238:54:

`error[E0599]: no method named 'send' found for struct 'futures_channel::mpsc::Sender' in the current scope`