### PR TITLE
Bugfix/fix fullname construct

### DIFF
--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -72,10 +72,10 @@ impl<'a> FullName<'a> {
 		let reg_type = crate::cstr::CStr::from(&self.reg_type)?;
 		let domain = crate::cstr::CStr::from(&self.domain)?;
 
-		const SIZE: usize = crate::ffi::MAX_DOMAIN_NAME + 200;
+		const SIZE: usize = crate::ffi::MAX_DOMAIN_NAME;
 		let mut buf: Vec<u8> = Vec::new();
-		buf.reserve(SIZE);
-		let len = unsafe {
+		buf.resize(SIZE, 0);
+		let result = unsafe {
 			crate::ffi::DNSServiceConstructFullName(
 				buf.as_mut_ptr() as *mut c_char,
 				service.as_ptr(),
@@ -84,12 +84,8 @@ impl<'a> FullName<'a> {
 			)
 		};
 
-		if len < 0 {
+		if result != 0 {
 			return Err(io::Error::new(io::ErrorKind::InvalidInput, "invalid input"));
-		}
-
-		unsafe {
-			buf.set_len(len as usize);
 		}
 
 		String::from_utf8(buf).map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))


### PR DESCRIPTION
The method [async_dnssd::FullName::construct()](https://stbuehler.github.io/rustdocs/async-dnssd/async_dnssd/struct.FullName.html#method.construct) interprets the return value of `DNSServiceConstructFullName` as length of the written string, but it actually returns an `kDNSServiceErr_NoError` (equal to 0) on succes or `kDNSServiceErr_BadParam` on error. 

As a result, each successful call to FullName::construct() would return a string of length zero.

This PR changes  `async_dnssd::FullName::construct()` so that it interprets the return value as ok/error and tries construct a valid UTF-8 string from given buffer until the first `0`.

I'm pretty fresh to Rust so if there are better ways to do this please let me know.